### PR TITLE
Limit class reference toctree expansion

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,17 +6,24 @@ Carbon.io Documentation
   :maxdepth: 2
 
   overview.rst
-  introduction.rst 
+  introduction.rst
   quick-start.rst
 
 .. toctree::
 
   packages/carbond/docs/guide/index
   carbon-core/index
+
+.. toctree::
+  :maxdepth: 1
+  :titlesonly:
+
   packages/carbond/docs/ref/index
+
+.. toctree::
   examples.rst
 
 .. toctree::
   :maxdepth: 1
-  
+
   support.rst


### PR DESCRIPTION
This moves the toctree arguments from the nested toctree up to the top level, to
ensure it on a global level.