### PR TITLE
Add community documents

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at support@mlab.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing to Carbon.io
+
+Thank you for considering contributing to Carbon.io. We're excited to build a great framework for command line programs, microservices, and APIs. We hope a wide range of people will come together to help build Carbon.io.
+
+Following these guidelines will help you get started contributing to Carbon.io. We love to receive new contributions! There are many ways to contribute, from writing tutorials or blog posts, improving the documentation, submitting bug reports and feature requests or writing code which can be incorporated into Carbon.io itself.
+
+## Your First Contribution
+If you're unsure where to begin contributing to Carbon.io, feel free to [submit an issue](https://github.com/carbon-io/carbon-io/issues/new) asking for guidance. We'll be happy to help find something for you.  
+
+A good starting point can be improving the docs. If you find anything missing or unclear, we'd love to receive input from you.
+
+## Project Structure
+
+Carbon.io is made out of several different repositories:
+
+- [`carbon-io`](https://github.com/carbon-io/carbon-io): The main repository which wraps the `carbon-core` modules and `carbond`
+  - [`carbond`](https://github.com/carbon-io/carbond): The server component of the Carbon.io framework
+  - [`carbon-core`](https://github.com/carbon-io/carbon-core): Wrapper for the modules that make up the Carbon.io framework
+    - [`atom`](https://github.com/carbon-io/atom): Dependency Injection library for creating re-usable Javascript components and command-line programs
+    - [`bond`](https://github.com/carbon-io/bond): Name resolver for Carbon.io
+    - [`ejson`](https://github.com/carbon-io/ejson): Utility for MongoDB Extended JSON
+    - [`fibers`](https://github.com/carbon-io/fibers): Coroutines for Node.js
+    - [`http-errors`](https://github.com/carbon-io/http-errors): Error classes representing HTTP error codes
+    - [`leafnode`](https://github.com/carbon-io/leafnode): MongoDB driver using fibers
+    - [`logging`](https://github.com/carbon-io/logging): Logger for Carbon.io
+    - [`test-tube`](https://github.com/carbon-io/test-tube): Testing framework for Carbon.io
+
+You will want to work on and submit a pull request to the repository you wish to change. If you need any help, feel free to [create an issue on `carbon-io`](https://github.com/carbon-io/carbon-io/issues/new). 
+
+## Testing and Submitting a Pull Request
+
+1. Create your own fork of the code
+    ```
+    $ git clone https://github.com/carbon-io/carbon-io
+    ```
+2. Do the changes in your fork
+3. Run tests 
+    ```
+    $ npm install
+    $ node test
+    ```
+3. Send a pull request
+
+Working on your first Pull Request? You can learn how from this series, [How to Contribute to an Open Source Project on GitHub](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github).
+
+## Building the docs
+
+You can find up to date instructions on how to build the docs on the [docs README](https://github.com/carbon-io/carbon-io/blob/master/docs/README.md).
+
+## Asking for help
+
+Feel free to ask for help by submitting an issue. Thank you for considering contributing to Carbon.io.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,22 @@
+The MIT License
+
+Copyright (c) 2012 - 2017 ObjectLabs Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,62 @@
 Carbon.io
 ==========
 
+[![Build Status](https://travis-ci.org/carbon-io/carbon-io.svg?branch=master)](https://travis-ci.org/carbon-io/carbon-io)
+
 Carbon.io is an application framework based on Node.js and MongoDB for building command line programs, microservices, and APIs.
 
-[Documentation](https://docs.carbon.io)
+With Carbon.io you can create simple, database-centric microservices with virtually no code. At the same time Carbon.io is designed to let you under the hood and allows you to write highly customized APIs much like you would with lower-level libraries such as Express.js.
+
+## Quickstart
+
+To install:
+
+```
+$ npm install carbon-io
+```
+
+Copy the following code into `service.js`:
+
+```js
+var carbon = require('carbon-io')
+
+var o  = carbon.atom.o(module).main
+var __ = carbon.fibers.__(module).main
+
+__(function() {
+  module.exports = o({
+    _type: carbon.carbond.Service,
+    port: 8888,
+    endpoints: {
+      hello: o({
+        _type: carbon.carbond.Endpoint,
+        get: function(req) {
+          return { msg: "Hello world!" }
+        }
+      })
+    }
+  })
+})
+```
+
+This will creat a Carbon.io service which will respond with "Hello world!" on the `/hello` endpoint. Run the service with:
+
+```
+$ node service
+```
+
+And test it using:
+
+```
+$ curl localhost:8888/hello
+```
+
+## Documentation
+
+Interested in getting started with Carbon.io? [__Check out our detailed documentation on the Carbon.io website.__](https://docs.carbon.io)
+
+## Contributing
+
+Interested in contributing to Carbon.io? We love to receive new contributions! There are many ways to contribute, from writing tutorials or blog posts, improving the documentation, submitting bug reports and feature requests or writing code which can be incorporated into Carbon.io itself.
+
+Check out our [CONTRIBUTING.md](/CONTRIBUTING.md) for tips on how to get started!

--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@ Interested in getting started with Carbon.io? [__Check out our detailed document
 
 Interested in contributing to Carbon.io? We love to receive new contributions! There are many ways to contribute, from writing tutorials or blog posts, improving the documentation, submitting bug reports and feature requests or writing code which can be incorporated into Carbon.io itself.
 
-Check out our [CONTRIBUTING.md](/CONTRIBUTING.md) for tips on how to get started!
+Check out our [CONTRIBUTING.md](./CONTRIBUTING.md) for tips on how to get started!


### PR DESCRIPTION
Adds a CONTRIBUTING.md and CONDE_OF_CONDUCT.md as it's considered best practice and will be helpful later down the line. Might not get any outside contributors for a while, but would be nice for potential contributors to feel welcome.

Updates the Readme a bit. We'll probably iterate on the readme a lot. I just want to get a starting point so it's not empty to anybody looking at the project on npm or GitHub. It looks bad if the readme's empty.

Adds the LICENSE.txt from carbond.